### PR TITLE
Improve mobile layout and chat toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,58 @@
 <html>
 <head>
   <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.css"/>
   <style>
-    #editor, #preview { width: 50%; height: 100vh; float: left; }
+    body { margin: 0; }
+    header {
+      background: #333;
+      color: #fff;
+      padding: 0.5rem;
+      text-align: center;
+      font-size: 1.25rem;
+    }
+    #main {
+      display: flex;
+      flex-direction: column;
+    }
+    #editor, #preview {
+      width: 100%;
+      height: 50vh;
+    }
+    #chat-toggle {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+    }
+    #chat-window {
+      display: none;
+      position: fixed;
+      bottom: 60px;
+      right: 20px;
+      width: 90%;
+      max-width: 300px;
+      height: 300px;
+      border: 1px solid #ccc;
+      background: #fff;
+    }
+    #chat-window.open { display: block; }
+    @media (min-width: 768px) {
+      header { font-size: 1.5rem; }
+      #main { flex-direction: row; }
+      #editor, #preview { width: 50%; height: calc(100vh - 50px); }
+    }
   </style>
 </head>
 <body>
-  <textarea id="editor"></textarea>
-  <iframe id="preview"></iframe>
+  <header>My App</header>
+  <div id="main">
+    <textarea id="editor"></textarea>
+    <iframe id="preview"></iframe>
+  </div>
+
+  <button id="chat-toggle">Chat</button>
+  <div id="chat-window">Chat window content</div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/codemirror.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.14/mode/htmlmixed/htmlmixed.min.js"></script>
@@ -32,6 +76,12 @@
     function updatePreview(val) {
       preview.srcdoc = val;
     }
+
+    const chatToggle = document.getElementById('chat-toggle');
+    const chatWindow = document.getElementById('chat-window');
+    chatToggle.addEventListener('click', () => {
+      chatWindow.classList.toggle('open');
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Make layout mobile-first with responsive header and stacked editor/preview
- Add chat button that toggles a hidden chat window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b87f56757c8327b84aad8d0b1cc4ab