### PR TITLE
docs: add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ This repository hosts a minimal browser-based collaborative code editor with liv
    ```
 
 3. Open [http://localhost:3000](http://localhost:3000) in your browser. Open the page in multiple tabs or browsers to see the shared editor in action.
+
+## Viewing on GitHub Pages
+
+The latest version of this project is available via GitHub Pages at
+[https://jasontduncan.github.io/sml/](https://jasontduncan.github.io/sml/).
+Simply visit the link to try the collaborative editor without running a local server.


### PR DESCRIPTION
## Summary
- document GitHub Pages deployment with direct link to live site

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b881e0083883279af503db37bf5c86